### PR TITLE
Change github.org to github.com for plugin page

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -11,7 +11,7 @@
         em:type="2"
         em:creator="Brenton M. Wiernik"
         em:description="Zotero plugin for auto-fetching and validating DOI and shortDOI names"
-        em:homepageURL="https://github.org/bwiernik/zotero-shortdoi"
+        em:homepageURL="https://github.com/bwiernik/zotero-shortdoi"
         em:updateURL="https://raw.githubusercontent.com/bwiernik/zotero-shortdoi/master/update.rdf">
         <em:type>2</em:type>
         <em:targetApplication>


### PR DESCRIPTION
Simple change of `github.org` to `github.com` so the link in the Add-on Manager resolves.